### PR TITLE
fix: [PAGOPA-2990] Defining explicit set for app timezone

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-stand-in-manager
 description: Microservice that handles Stand-In activation/deactivation process
 type: application
-version: 0.92.0
-appVersion: 0.1.3-1-PAGOPA-2990
+version: 0.93.0
+appVersion: 0.1.3-2-PAGOPA-2990
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-stand-in-manager
 description: Microservice that handles Stand-In activation/deactivation process
 type: application
-version: 0.91.0
-appVersion: 0.1.3
+version: 0.92.0
+appVersion: 0.1.3-1-PAGOPA-2990
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-stand-in-manager
 description: Microservice that handles Stand-In activation/deactivation process
 type: application
-version: 0.93.0
-appVersion: 0.1.3-2-PAGOPA-2990
+version: 0.94.0
+appVersion: 0.1.3-3-PAGOPA-2990
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3-2-PAGOPA-2990"
+    tag: "0.1.3-3-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3-1-PAGOPA-2990"
+    tag: "0.1.3-2-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness
@@ -33,7 +33,7 @@ microservice-chart:
     name: "nodo-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: { }
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -33,7 +33,7 @@ microservice-chart:
     name: "nodo-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -83,6 +83,7 @@ microservice-chart:
     OTEL_LOGS_EXPORTER: none
     OTEL_TRACES_SAMPLER: "always_on"
     STAND_IN_TX_NAME: "nodo-dei-pagamenti-stand-in"
+    JAVA_OPTS: "-Duser.timezone=Europe/Rome"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -50,6 +50,7 @@ microservice-chart:
     enable: false
   envConfig:
     WEBSITE_SITE_NAME: 'pagopa-stand-in-manager' # required to show cloud role name in application insights
+    TZ: "Europe/Rome"
     ENV: 'dev'
     APP_LOGGING_LEVEL: 'DEBUG'
     DEFAULT_LOGGING_LEVEL: 'INFO'
@@ -83,7 +84,6 @@ microservice-chart:
     OTEL_LOGS_EXPORTER: none
     OTEL_TRACES_SAMPLER: "always_on"
     STAND_IN_TX_NAME: "nodo-dei-pagamenti-stand-in"
-    JAVA_OPTS: "-Duser.timezone=Europe/Rome"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3"
+    tag: "0.1.3-1-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3-2-PAGOPA-2990"
+    tag: "0.1.3-3-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -50,6 +50,7 @@ microservice-chart:
     enable: false
   envConfig:
     WEBSITE_SITE_NAME: 'pagopa-stand-in-manager' # required to show cloud role name in application insights
+    TZ: "Europe/Rome"
     ENV: 'prod'
     APP_LOGGING_LEVEL: 'INFO'
     DEFAULT_LOGGING_LEVEL: 'INFO'
@@ -83,7 +84,6 @@ microservice-chart:
     OTEL_LOGS_EXPORTER: none
     OTEL_TRACES_SAMPLER: "always_on"
     STAND_IN_TX_NAME: "nodo-dei-pagamenti-stand-in"
-    JAVA_OPTS: "-Duser.timezone=Europe/Rome"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: "azure-insight-connection-string"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3-1-PAGOPA-2990"
+    tag: "0.1.3-2-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness
@@ -33,7 +33,7 @@ microservice-chart:
     name: "nodo-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: { }
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -123,7 +123,7 @@ microservice-chart:
             labelSelector:
               matchLabels:
                 app.kubernetes.io/instance: "pagopa-stand-in-manager"
-            namespaces: [ "nodo" ]
+            namespaces: ["nodo"]
             topologyKey: topology.kubernetes.io/zone
   canaryDelivery:
     create: false

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -33,7 +33,7 @@ microservice-chart:
     name: "nodo-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -83,6 +83,7 @@ microservice-chart:
     OTEL_LOGS_EXPORTER: none
     OTEL_TRACES_SAMPLER: "always_on"
     STAND_IN_TX_NAME: "nodo-dei-pagamenti-stand-in"
+    JAVA_OPTS: "-Duser.timezone=Europe/Rome"
   envSecret:
     # required
     APPLICATIONINSIGHTS_CONNECTION_STRING: "azure-insight-connection-string"
@@ -122,7 +123,7 @@ microservice-chart:
             labelSelector:
               matchLabels:
                 app.kubernetes.io/instance: "pagopa-stand-in-manager"
-            namespaces: ["nodo"]
+            namespaces: [ "nodo" ]
             topologyKey: topology.kubernetes.io/zone
   canaryDelivery:
     create: false

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3"
+    tag: "0.1.3-1-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3-2-PAGOPA-2990"
+    tag: "0.1.3-3-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3-1-PAGOPA-2990"
+    tag: "0.1.3-2-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness
@@ -33,7 +33,7 @@ microservice-chart:
     name: "nodo-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: { }
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -33,7 +33,7 @@ microservice-chart:
     name: "nodo-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -83,6 +83,7 @@ microservice-chart:
     OTEL_LOGS_EXPORTER: none
     OTEL_TRACES_SAMPLER: "always_on"
     STAND_IN_TX_NAME: "nodo-dei-pagamenti-stand-in"
+    JAVA_OPTS: "-Duser.timezone=Europe/Rome"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -50,6 +50,7 @@ microservice-chart:
     enable: false
   envConfig:
     WEBSITE_SITE_NAME: 'pagopa-stand-in-manager' # required to show cloud role name in application insights
+    TZ: "Europe/Rome"
     ENV: 'uat'
     APP_LOGGING_LEVEL: 'DEBUG'
     DEFAULT_LOGGING_LEVEL: 'INFO'
@@ -83,7 +84,6 @@ microservice-chart:
     OTEL_LOGS_EXPORTER: none
     OTEL_TRACES_SAMPLER: "always_on"
     STAND_IN_TX_NAME: "nodo-dei-pagamenti-stand-in"
-    JAVA_OPTS: "-Duser.timezone=Europe/Rome"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart:
   namespace: "nodo"
   image:
     repository: ghcr.io/pagopa/pagopa-stand-in-manager
-    tag: "0.1.3"
+    tag: "0.1.3-1-PAGOPA-2990"
   livenessProbe:
     httpGet:
       path: /actuator/health/liveness

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Stand in Manager",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "@project.name@",
-    "version": "0.1.3-2-PAGOPA-2990"
+    "version": "0.1.3-3-PAGOPA-2990"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Stand in Manager",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "@project.name@",
-    "version": "0.1.3-1-PAGOPA-2990"
+    "version": "0.1.3-2-PAGOPA-2990"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "description": "Stand in Manager",
     "termsOfService": "https://www.pagopa.gov.it/",
     "title": "@project.name@",
-    "version": "0.1.3"
+    "version": "0.1.3-1-PAGOPA-2990"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>it.gov.pagopa</groupId>
   <artifactId>stand-in-manager</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.3-1-PAGOPA-2990</version>
   <description>Stand in Manager</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>it.gov.pagopa</groupId>
   <artifactId>stand-in-manager</artifactId>
-  <version>0.1.3-1-PAGOPA-2990</version>
+  <version>0.1.3-2-PAGOPA-2990</version>
   <description>Stand in Manager</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>it.gov.pagopa</groupId>
   <artifactId>stand-in-manager</artifactId>
-  <version>0.1.3-2-PAGOPA-2990</version>
+  <version>0.1.3-3-PAGOPA-2990</version>
   <description>Stand in Manager</description>
 
   <properties>

--- a/src/main/java/it/gov/pagopa/standinmanager/Application.java
+++ b/src/main/java/it/gov/pagopa/standinmanager/Application.java
@@ -18,7 +18,6 @@ import software.amazon.awssdk.services.ses.SesClient;
 
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.TimeZone;
 
 @SpringBootApplication
 public class Application {
@@ -45,18 +44,7 @@ public class Application {
     private Integer forwarderReadTimeout;
 
     public static void main(String[] args) {
-        setTimezone(args);
         SpringApplication.run(Application.class, args);
-    }
-
-    private static void setTimezone(String[] args) {
-        for (String arg : args) {
-            String[] argSections = arg.split("=");
-            if (argSections[0].contains("user.timezone")) {
-                TimeZone.setDefault(TimeZone.getTimeZone(argSections[1]));
-                return;
-            }
-        }
     }
 
     @Bean

--- a/src/main/java/it/gov/pagopa/standinmanager/Application.java
+++ b/src/main/java/it/gov/pagopa/standinmanager/Application.java
@@ -6,8 +6,7 @@ import com.microsoft.azure.kusto.data.Client;
 import com.microsoft.azure.kusto.data.ClientFactory;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import it.gov.pagopa.standinmanager.config.ApiClient;
-import java.net.URISyntaxException;
-import java.time.Duration;
+import jakarta.annotation.PostConstruct;
 import org.openapitools.client.api.CacheApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -18,72 +17,74 @@ import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ses.SesClient;
 
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class Application {
 
-  public static void main(String[] args) {
-    SpringApplication.run(Application.class, args);
-  }
+    @Value("${api-config-cache.base-path}")
+    private String basePath;
+    @Value("${api-config-cache.api-key}")
+    private String apiKey;
+    @Value("${dataexplorer.url}")
+    private String dataExplorerUrl;
+    @Value("${dataexplorer.clientId}")
+    private String dataExplorerClientId;
+    @Value("${dataexplorer.appKey}")
+    private String dataExplorerKey;
+    @Value("${cosmos.endpoint}")
+    private String cosmosEndpoint;
+    @Value("${cosmos.key}")
+    private String cosmosKey;
+    @Value("${aws.region}")
+    private String region;
+    @Value("${timezone}")
+    private String timezone;
+    @Value("${forwarder.connectionTimeout}")
+    private Integer forwarderConnectTimeout;
+    @Value("${forwarder.readTimeout}")
+    private Integer forwarderReadTimeout;
 
-  @Value("${api-config-cache.base-path}")
-  private String basePath;
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 
-  @Value("${api-config-cache.api-key}")
-  private String apiKey;
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone(timezone));
+    }
 
-  @Value("${dataexplorer.url}")
-  private String dataExplorerUrl;
+    @Bean
+    public SesClient sesClient() {
+        return SesClient.builder().region(Region.of(region)).build();
+    }
 
-  @Value("${dataexplorer.clientId}")
-  private String dataExplorerClientId;
+    @Bean
+    public CacheApi cacheApi() {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(basePath);
+        apiClient.setApiKey(apiKey);
+        return new CacheApi(apiClient);
+    }
 
-  @Value("${dataexplorer.appKey}")
-  private String dataExplorerKey;
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setReadTimeout(Duration.ofSeconds(forwarderReadTimeout))
+                .setConnectTimeout(Duration.ofSeconds(forwarderConnectTimeout))
+                .build();
+    }
 
-  @Value("${cosmos.endpoint}")
-  private String cosmosEndpoint;
+    @Bean
+    public Client getClient() throws URISyntaxException {
+        return ClientFactory.createClient(
+                ConnectionStringBuilder.createWithAadManagedIdentity(dataExplorerUrl));
+    }
 
-  @Value("${cosmos.key}")
-  private String cosmosKey;
-
-  @Value("${aws.region}")
-  private String region;
-
-  @Value("${forwarder.connectionTimeout}")
-  private Integer forwarderConnectTimeout;
-
-  @Value("${forwarder.readTimeout}")
-  private Integer forwarderReadTimeout;
-
-  @Bean
-  public SesClient sesClient() {
-    return SesClient.builder().region(Region.of(region)).build();
-  }
-
-  @Bean
-  public CacheApi cacheApi() {
-    ApiClient apiClient = new ApiClient();
-    apiClient.setBasePath(basePath);
-    apiClient.setApiKey(apiKey);
-    return new CacheApi(apiClient);
-  }
-
-  @Bean
-  public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder
-        .setReadTimeout(Duration.ofSeconds(forwarderReadTimeout))
-        .setConnectTimeout(Duration.ofSeconds(forwarderConnectTimeout))
-        .build();
-  }
-
-  @Bean
-  public Client getClient() throws URISyntaxException {
-    return ClientFactory.createClient(
-        ConnectionStringBuilder.createWithAadManagedIdentity(dataExplorerUrl));
-  }
-
-  @Bean
-  public CosmosClient getCosmosClient() {
-    return new CosmosClientBuilder().endpoint(cosmosEndpoint).key(cosmosKey).buildClient();
-  }
+    @Bean
+    public CosmosClient getCosmosClient() {
+        return new CosmosClientBuilder().endpoint(cosmosEndpoint).key(cosmosKey).buildClient();
+    }
 }

--- a/src/main/java/it/gov/pagopa/standinmanager/Application.java
+++ b/src/main/java/it/gov/pagopa/standinmanager/Application.java
@@ -6,7 +6,6 @@ import com.microsoft.azure.kusto.data.Client;
 import com.microsoft.azure.kusto.data.ClientFactory;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import it.gov.pagopa.standinmanager.config.ApiClient;
-import jakarta.annotation.PostConstruct;
 import org.openapitools.client.api.CacheApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -40,20 +39,24 @@ public class Application {
     private String cosmosKey;
     @Value("${aws.region}")
     private String region;
-    @Value("${timezone}")
-    private String timezone;
     @Value("${forwarder.connectionTimeout}")
     private Integer forwarderConnectTimeout;
     @Value("${forwarder.readTimeout}")
     private Integer forwarderReadTimeout;
 
     public static void main(String[] args) {
+        setTimezone(args);
         SpringApplication.run(Application.class, args);
     }
 
-    @PostConstruct
-    public void init() {
-        TimeZone.setDefault(TimeZone.getTimeZone(timezone));
+    private static void setTimezone(String[] args) {
+        for (String arg : args) {
+            String[] argSections = arg.split("=");
+            if (argSections[0].contains("user.timezone")) {
+                TimeZone.setDefault(TimeZone.getTimeZone(argSections[1]));
+                return;
+            }
+        }
     }
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,7 +17,6 @@ springdoc.writer-with-default-pretty-printer=true
 # Server
 server.servlet.context-path=/
 server.port=8080
-timezone=${TIMEZONE:Europe/Rome}
 # Logging
 logging.level.root=${DEFAULT_LOGGING_LEVEL:INFO}
 logging.level.it.gov.pagopa=${APP_LOGGING_LEVEL:INFO}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,7 @@ springdoc.writer-with-default-pretty-printer=true
 # Server
 server.servlet.context-path=/
 server.port=8080
+timezone=${TIMEZONE:Europe/Rome}
 # Logging
 logging.level.root=${DEFAULT_LOGGING_LEVEL:INFO}
 logging.level.it.gov.pagopa=${APP_LOGGING_LEVEL:INFO}
@@ -26,22 +27,17 @@ cors.configuration=${CORS_CONFIGURATION:'{"origins": ["*"], "methods": ["*"]}'}
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-
 api-config-cache.base-path=${API_CONFIG_CACHE_BASE_PATH}
 api-config-cache.api-key=${API_CONFIG_CACHE_API_KEY}
-
 dataexplorer.url=${DATAEXPLORER_URL}
 dataexplorer.clientId=
 dataexplorer.appKey=
 dataexplorer.dbName=re
-
 cosmos.endpoint=${COSMOS_ENDPOINT}
 cosmos.key=${COSMOS_KEY}
 cosmos.db.name=standin
-
 forwarder.url=${FORWARDER_URL}
 forwarder.key=${FORWARDER_KEY}
-
 # station goes into stand-in
 # minutes to group verify/activate requests
 adder.slot.minutes=${ADDER_SLOT_MINUTES}
@@ -51,31 +47,24 @@ adder.slot.fault.threshold=${ADDER_SLOT_FAULT_THRESHOLD}
 adder.range.minutes=${ADDER_RANGE_MINUTES}
 # if ko is greater than the threshold then station goes in stand-in mode
 adder.range.fault.threshold=${ADDER_RANGE_FAULT_THRESHOLD}
-
 # station leaves into stand-in
 remover.range.minutes=${REMOVER_SLOT_MINUTES}
 # if ko is lesser than the threshold then station leaves in stand-in mode
 remover.range.fault.limit=${REMOVER_SLOT_FAULT_LIMIT}
-
 # excluded stations from monitor
 excludedStations=${EXCLUDED_STATIONS}
-
 aws.region=${AWS_REGION}
 aws.ses.user=${AWS_SES_USER}
 aws.mailto=${AWS_MAILTO}
-
 config.refresh.cron=${CONFIG_REFRESH_CRON}
 nodo.monitor.cron=${NODO_MONITOR_CRON}
 nodo.calc.cron=${NODO_CALC_CRON}
 station.monitor.cron=${STATION_MONITOR_CRON}
 station.calc.cron=${STATION_CALC_CRON}
-
 #EventHub
 nodo-dei-pagamenti-stand-in-tx-connection-string=${STAND_IN_TX_CONNECTION_STRING}
 nodo-dei-pagamenti-stand-in-tx-name=${STAND_IN_TX_NAME:nodo-dei-pagamenti-stand-in}
-
 saveDB=false
 sendEvent=true
-
 forwarder.connectionTimeout=10
 forwarder.readTimeout=10


### PR DESCRIPTION
This PR contains a little change on application timezone, made in order to fix a unwanted behavior.  
After a manual integration test session, it was discovered that the queries made on the Data Explorer and the CosmosDB containers take an inconsistent timezone. While for the queries on CosmosDB there are no problems on which timezone must be used (they are read and written in timestamp format and so they are easily convertible with the required timezone), for the Data Explorer queries the inconsistency causes time-slots to be too large: at the date of writing this (2025/05/07), the queries defined a time-slot with a duration of 2h5m and this was essentially caused by the _daylight saving time_ (thus GMT+2).  
With this fix, the timezone is explicitly set on `"Europe/Rome"` timezone, using correctly dimensioned time-slots.

#### List of Changes
 - Added parameter for explicitly set timezone value 

#### Motivation and Context
This change permits to resolve a bug on statistic generation

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
